### PR TITLE
Replace OpenCV image with distro runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,21 @@
-FROM debian:stretch
+FROM ubuntu:24.04
 
-ENV OPENCV4NODEJS_DISABLE_AUTOBUILD=1
-ENV NODEJS_MAJOR_VERSION=13 OPENCV_VERSION=3.4.1 WITH_CONTRIB=1
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y build-essential curl && \
-    apt-get install -y --no-install-recommends wget unzip git python cmake && \
-    curl -sL https://deb.nodesource.com/setup_${NODEJS_MAJOR_VERSION}.x | bash && \
-    apt-get install -y nodejs && \
-    node -v && \
-    npm -v && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir opencv && \
-    cd opencv && \
-    wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip --no-check-certificate -O opencv-${OPENCV_VERSION}.zip && \
-    unzip opencv-${OPENCV_VERSION}.zip && \
-    if [ -n "$WITH_CONTRIB" ]; then 	\
-        wget https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip --no-check-certificate -O opencv_contrib-${OPENCV_VERSION}.zip; 	\
-        unzip opencv_contrib-${OPENCV_VERSION}.zip; \
-    fi && \
-    mkdir opencv-${OPENCV_VERSION}/build && \
-    cd opencv-${OPENCV_VERSION}/build && \
-    cmake_flags="-D CMAKE_BUILD_TYPE=RELEASE 	-D BUILD_DOCS=OFF 	-D BUILD_TESTS=OFF 	-D BUILD_PERF_TESTS=OFF 	-D BUILD_JAVA=OFF 	-D BUILD_opencv_apps=OFF 	-D BUILD_opencv_aruco=OFF 	-D BUILD_opencv_bgsegm=OFF 	-D BUILD_opencv_bioinspired=OFF 	-D BUILD_opencv_ccalib=OFF 	-D BUILD_opencv_datasets=OFF 	-D BUILD_opencv_dnn_objdetect=OFF 	-D BUILD_opencv_dpm=OFF 	-D BUILD_opencv_fuzzy=OFF 	-D BUILD_opencv_hfs=OFF 	-D BUILD_opencv_java_bindings_generator=OFF 	-D BUILD_opencv_js=OFF   -D BUILD_opencv_img_hash=OFF   -D BUILD_opencv_line_descriptor=OFF   -D BUILD_opencv_optflow=OFF   -D BUILD_opencv_phase_unwrapping=OFF 	-D BUILD_opencv_python3=OFF 	-D BUILD_opencv_python_bindings_generator=OFF 	-D BUILD_opencv_reg=OFF 	-D BUILD_opencv_rgbd=OFF 	-D BUILD_opencv_saliency=OFF 	-D BUILD_opencv_shape=OFF 	-D BUILD_opencv_stereo=OFF 	-D BUILD_opencv_stitching=OFF 	-D BUILD_opencv_structured_light=OFF 	-D BUILD_opencv_superres=OFF 	-D BUILD_opencv_surface_matching=OFF 	-D BUILD_opencv_ts=OFF 	-D BUILD_opencv_xobjdetect=OFF 	-D BUILD_opencv_xphoto=OFF 	-D CMAKE_BUILD_TYPE=RELEASE 	-D CMAKE_INSTALL_PREFIX=/usr/local" && \
-    if [ -n "$WITH_CONTRIB" ]; then   \
-        cmake_flags="$cmake_flags -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules"; \
-    fi && \
-    echo $cmake_flags && \
-    cmake $cmake_flags .. && \
-    make -j $(nproc) && \
-    make install && \
-    sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/opencv.conf' && \
-    ldconfig && \
-    cd ../../../ && \
-    rm -rf opencv && \
-    npm install -g opencv4nodejs --unsafe-perm && \
-    apt-get purge -y build-essential curl wget unzip git cmake && \
-    apt-get autoremove -y --purge
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libopencv-dev \
+    pkg-config \
+    python3-opencv \
+    && opencv_version \
+    && pkg-config --modversion opencv4 \
+    && python3 -c "import cv2; print(cv2.__version__)" \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/generate-mask.py /usr/local/bin/opencv-generate-mask
+
+RUN chmod +x /usr/local/bin/opencv-generate-mask
+
+WORKDIR /data
+
+CMD ["opencv_version"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,98 @@
 # docker-opencv
 
-Create a base opencv docker image with latest node
+Docker image for running distro-packaged OpenCV from an Ubuntu 24.04 container.
+
+This image is intentionally conservative: it uses Ubuntu's maintained `libopencv-dev` and `python3-opencv` packages instead of building OpenCV from source. It provides OpenCV command-line smoke checks, C/C++ development headers and libraries, `pkg-config` metadata, and Python `cv2` bindings.
+
+This image does not include Node.js or `opencv4nodejs`.
+
+## Build
+
+```bash
+docker build -t docker-opencv:test .
+```
+
+The release image path configured by `deploy.json` is:
+
+```text
+australia-southeast1-docker.pkg.dev/cognitive-code/opencv/main
+```
+
+## Smoke Test
+
+The default command prints the installed OpenCV version:
+
+```bash
+docker run --rm docker-opencv:test
+```
+
+You can also check the C/C++ package metadata and Python binding:
+
+```bash
+docker run --rm docker-opencv:test pkg-config --modversion opencv4
+docker run --rm docker-opencv:test python3 -c "import cv2; print(cv2.__version__)"
+```
+
+## Inspect An Image With Python
+
+Mount the directory containing your files as `/data`, then reference paths inside `/data`:
+
+```bash
+docker run --rm \
+  -v "$PWD:/data:ro" \
+  docker-opencv:test \
+  python3 -c "import cv2; img = cv2.imread('/data/example.png'); print(img.shape if img is not None else 'unreadable')"
+```
+
+For a file in another directory:
+
+```bash
+IMAGE_DIR="$HOME/cognitiveEarth/view-utilities/test/output/downloads/virtual-mnsw-pipeline/all/pngs-pseudo-lvl5/buffers_all_POSITION/20"
+IMAGE_FILE="pseudo_lvl5_from_lvl6_117_43_to_117_44.contentLength.png"
+
+docker run --rm \
+  -v "$IMAGE_DIR:/data:ro" \
+  docker-opencv:test \
+  python3 -c "import cv2; img = cv2.imread('/data/$IMAGE_FILE'); print(img.shape if img is not None else 'unreadable')"
+```
+
+## Generate A Mask
+
+The image includes `opencv-generate-mask`, a small CLI for generating the accepted hole-preserving mask. Its defaults are:
+
+```text
+threshold=8
+kernel-size=5
+close-iterations=2
+preserve-holes=2
+```
+
+Run it by mounting the image directory as `/data`:
+
+```bash
+IMAGE_DIR="$HOME/cognitiveEarth/view-utilities/test/output/downloads/virtual-mnsw-pipeline/all/pngs-pseudo-lvl5-lvl14px/buffers_all_POSITION/16"
+IMAGE_FILE="pseudo_lvl5_1px_per_lvl14_from_z16_lvl6_117_43_to_117_44.contentLength.png"
+MASK_FILE="${IMAGE_FILE%.png}.mask.preserve-2-holes.threshold8.close5x5.iter2.png"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$IMAGE_DIR:/data" \
+  docker-opencv:test \
+  opencv-generate-mask "/data/$IMAGE_FILE" "/data/$MASK_FILE"
+```
+
+The equivalent explicit form is:
+
+```bash
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$IMAGE_DIR:/data" \
+  docker-opencv:test \
+  opencv-generate-mask \
+    --threshold 8 \
+    --kernel-size 5 \
+    --close-iterations 2 \
+    --preserve-holes 2 \
+    "/data/$IMAGE_FILE" \
+    "/data/$MASK_FILE"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognitive-earth/docker-opencv",
-  "version": "13.0.3",
+  "version": "13.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognitive-earth/docker-opencv",
-      "version": "13.0.3",
+      "version": "13.0.4",
       "license": "UNLICENSED",
       "devDependencies": {
         "@cognitive-earth/framework-release": "^0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive-earth/docker-opencv",
-  "version": "13.0.3",
+  "version": "13.0.4",
   "description": "Manage OpenCV docker image releases",
   "homepage": "https://github.com/cognitive-earth/docker-opencv#readme",
   "publishConfig": {

--- a/scripts/generate-mask.py
+++ b/scripts/generate-mask.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate a binary OpenCV mask while preserving selected enclosed holes."
+    )
+    parser.add_argument("input", help="Input image path.")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="Output mask path. Defaults to a parameter-stamped name beside the input.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=8,
+        help="Foreground threshold; pixels greater than this become foreground.",
+    )
+    parser.add_argument(
+        "--kernel-size",
+        type=int,
+        default=5,
+        help="Elliptical morphology kernel size.",
+    )
+    parser.add_argument(
+        "--close-iterations",
+        type=int,
+        default=2,
+        help="Number of morphology close iterations.",
+    )
+    parser.add_argument(
+        "--preserve-holes",
+        type=int,
+        default=2,
+        help="Number of largest enclosed dark holes to preserve in the final mask.",
+    )
+    return parser.parse_args()
+
+
+def default_output_path(input_path, threshold, kernel_size, close_iterations, preserve_holes):
+    suffix = (
+        f".mask.preserve-{preserve_holes}-holes"
+        f".threshold{threshold}.close{kernel_size}x{kernel_size}"
+        f".iter{close_iterations}.png"
+    )
+    return input_path.with_suffix(suffix)
+
+
+def validate_args(args):
+    if not 0 <= args.threshold <= 255:
+        raise SystemExit("--threshold must be between 0 and 255")
+    if args.kernel_size < 1 or args.kernel_size % 2 == 0:
+        raise SystemExit("--kernel-size must be a positive odd integer")
+    if args.close_iterations < 0:
+        raise SystemExit("--close-iterations must be zero or greater")
+    if args.preserve_holes < 0:
+        raise SystemExit("--preserve-holes must be zero or greater")
+
+
+def main():
+    args = parse_args()
+    validate_args(args)
+
+    input_path = Path(args.input)
+    output_path = (
+        Path(args.output)
+        if args.output
+        else default_output_path(
+            input_path,
+            args.threshold,
+            args.kernel_size,
+            args.close_iterations,
+            args.preserve_holes,
+        )
+    )
+
+    img = cv2.imread(str(input_path), cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        raise SystemExit(f"Could not read image: {input_path}")
+
+    _, raw_fg = cv2.threshold(img, args.threshold, 255, cv2.THRESH_BINARY)
+
+    kernel = cv2.getStructuringElement(
+        cv2.MORPH_ELLIPSE,
+        (args.kernel_size, args.kernel_size),
+    )
+    closed_fg = cv2.morphologyEx(
+        raw_fg,
+        cv2.MORPH_CLOSE,
+        kernel,
+        iterations=args.close_iterations,
+    )
+
+    n, labels, stats, _ = cv2.connectedComponentsWithStats(closed_fg, 8)
+    if n <= 1:
+        raise SystemExit("No foreground object found")
+
+    largest = 1 + np.argmax(stats[1:, cv2.CC_STAT_AREA])
+    outer_mask = np.where(labels == largest, 255, 0).astype(np.uint8)
+
+    holes_to_preserve = np.zeros_like(raw_fg)
+    selected_holes = []
+    if args.preserve_holes:
+        raw_bg_inside_outer = np.where(
+            (outer_mask == 255) & (raw_fg == 0),
+            255,
+            0,
+        ).astype(np.uint8)
+        num_holes, hole_labels, hole_stats, _ = cv2.connectedComponentsWithStats(
+            raw_bg_inside_outer,
+            8,
+        )
+
+        candidates = []
+        for label in range(1, num_holes):
+            x = int(hole_stats[label, cv2.CC_STAT_LEFT])
+            y = int(hole_stats[label, cv2.CC_STAT_TOP])
+            w = int(hole_stats[label, cv2.CC_STAT_WIDTH])
+            h = int(hole_stats[label, cv2.CC_STAT_HEIGHT])
+            area = int(hole_stats[label, cv2.CC_STAT_AREA])
+
+            touches_image_boundary = (
+                x == 0
+                or y == 0
+                or x + w == raw_fg.shape[1]
+                or y + h == raw_fg.shape[0]
+            )
+            if not touches_image_boundary:
+                candidates.append((area, label, x, y, w, h))
+
+        candidates.sort(key=lambda candidate: (-candidate[0], candidate[1]))
+        selected_holes = candidates[: args.preserve_holes]
+
+        for _, label, *_ in selected_holes:
+            holes_to_preserve[hole_labels == label] = 255
+
+    mask = outer_mask.copy()
+    mask[holes_to_preserve == 255] = 0
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if not cv2.imwrite(str(output_path), mask):
+        raise SystemExit(f"Could not write mask: {output_path}")
+
+    selected = ", ".join(
+        f"area={area} bbox=({x},{y},{w},{h})"
+        for area, _, x, y, w, h in selected_holes
+    )
+    print(f"input={input_path}")
+    print(f"output={output_path}")
+    print(f"source_shape={img.shape}")
+    print(f"outer_area={int(stats[largest, cv2.CC_STAT_AREA])}")
+    print(f"preserve_holes={args.preserve_holes}")
+    print(f"selected_holes={selected or 'none'}")
+    print(f"mask_white_pixels={int(np.count_nonzero(mask))}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updates the OpenCV Docker image to Ubuntu 24.04 distro packages, adds the opencv-generate-mask helper, and bumps the package to v13.0.4.